### PR TITLE
fix: pin sauce connect version

### DIFF
--- a/testcafe/browser-provider/.sauce/config.yml
+++ b/testcafe/browser-provider/.sauce/config.yml
@@ -3,10 +3,11 @@ kind: imagerunner
 sauce:
   region: us-west-1
 suites:
-  - name: TestCafe with Sauce Labs Browser Provider in Image Runner 
+  - name: TestCafe with Sauce Labs Browser Provider in Image Runner
     workload: other
     image: saucelabs/imagerunner-testcafe-browser-provider-example:latest
     entrypoint: npx testcafe "saucelabs:chrome@121:Windows 11" "/app/tests/**/*.test.js"
     env:
       SAUCE_USERNAME: $SAUCE_USERNAME
       SAUCE_ACCESS_KEY: $SAUCE_ACCESS_KEY
+      SAUCE_CONNECT_VERSION: 4.9.2


### PR DESCRIPTION
## Description

The third party provider plugin does not seem to like Sauce Connect 5. Pin to 4.