### PR TITLE
docs: caution against testcafe browser provider plugin

### DIFF
--- a/testcafe/browser-provider/README.md
+++ b/testcafe/browser-provider/README.md
@@ -2,6 +2,10 @@
 
 This example demonstrates how to run TestCafe tests using the Sauce Labs browser provider plugin with saucectl and Sauce Orchestrate.
 
+⚠️ **The provider plugin is not maintained by Sauce Labs and is currently
+experiencing a variety of issues. However, we'd love to [hear from you](devx@saucelabs.com)
+if you'd like us to provide a first party plugin instead.**
+
 ## Setup
 
 ### Install saucectl
@@ -21,7 +25,7 @@ Alternative installation methods are described [here](https://docs.saucelabs.com
 saucectl configure
 ```
 
-## Usage 
+## Usage
 
 ```shell
 saucectl run --config .sauce/config.yml


### PR DESCRIPTION
## Description

Caution against the use of the plugin, or at least, make users aware that there are issues.